### PR TITLE
serializing datetime with the format coming from config

### DIFF
--- a/src/Models/LogToDbCreateObject.php
+++ b/src/Models/LogToDbCreateObject.php
@@ -57,44 +57,37 @@ trait LogToDbCreateObject
                     $newexception['class'] = get_class($exception);
                     if (method_exists($exception, 'getMessage')) {
                         $newexception['message'] = $exception->getMessage();
-                    }
-                    else {
+                    } else {
                         $newexception['message'] = '';
                     }
                     if (method_exists($exception, 'getCode')) {
                         $newexception['code'] = $exception->getCode();
-                    }
-                    else {
+                    } else {
                         $newexception['code'] = '';
                     }
                     if (method_exists($exception, 'getFile')) {
                         $newexception['file'] = $exception->getFile();
-                    }
-                    else {
+                    } else {
                         $newexception['file'] = '';
                     }
                     if (method_exists($exception, 'getLine')) {
                         $newexception['line'] = $exception->getLine();
-                    }
-                    else {
+                    } else {
                         $newexception['line'] = '';
                     }
                     if (method_exists($exception, 'getTrace')) {
                         $newexception['trace'] = $exception->getTrace();
-                    }
-                    else {
+                    } else {
                         $newexception['trace'] = '';
                     }
                     if (method_exists($exception, 'getPrevious')) {
                         $newexception['previous'] = $exception->getPrevious();
-                    }
-                    else {
+                    } else {
                         $newexception['previous'] = '';
                     }
                     if (method_exists($exception, 'getSeverity')) {
                         $newexception['severity'] = $exception->getSeverity();
-                    }
-                    else {
+                    } else {
                         $newexception['severity'] = '';
                     }
 
@@ -112,7 +105,7 @@ trait LogToDbCreateObject
      */
     public function setDatetimeAttribute(object $value)
     {
-        $this->attributes['datetime'] = serialize($value);
+        $this->attributes['datetime'] = serialize($value->format(config('logtodb.datetime_format')));
     }
 
     /**
@@ -208,7 +201,7 @@ trait LogToDbCreateObject
         $unixtime = strtotime($datetime);
         $deletes = $this->where('unix_time', '<=', $unixtime)->get();
 
-        if (!$deletes->isEmpty()){
+        if (!$deletes->isEmpty()) {
             if ($deletes->each->delete()) {
                 return true;
             }

--- a/src/config/logtodb.php
+++ b/src/config/logtodb.php
@@ -103,7 +103,14 @@ return [
     */
     'purge_log_when_max_records' => env('LOG_DB_MAX_COUNT', false), //Ex: 1000 records
 
-    'purge_log_when_max_hours' => env('LOG_DB_MAX_HOURS', false) //Ex: 24 for 24 hours. Or 24*7 = 1 week.
 
+    'purge_log_when_max_hours' => env('LOG_DB_MAX_HOURS', false), //Ex: 24 for 24 hours. Or 24*7 = 1 week.
+
+    /*
+     |
+     | Specify the datetime format storing into the log record
+     |
+     */
+    'datetime_format' => env('LOG_DB_DATETIME_FORMAT', 'Y-m-d H:i:s:ms')
 
 ];


### PR DESCRIPTION
Hi!
I was trying to get the stored logs from DB:
````php
LogToDB::model('database')->get()
````
and with the default behavior of the package, I face with the error: `unserialize(): Error at offset 38 of 42 bytes at /var/www/vendor/danielme85/laravel-log-to-db/src/Models/LogToDbCreateObject.php:31)`

I've made a little changes to fix this and also added a new config element for formatting the `datetime`

in `config/logtodb.php`:
````php
'datetime_format' => env('LOG_DB_DATETIME_FORMAT', 'Y-m-d H:i:s:ms')
````
