### PR TITLE
Wrong format of exception in log context fix

### DIFF
--- a/src/LogToDbCustomLoggingHandler.php
+++ b/src/LogToDbCustomLoggingHandler.php
@@ -55,7 +55,7 @@ class LogToDbCustomLoggingHandler extends AbstractProcessingHandler
     protected function write(array $record): void
     {
         if (!empty($record)) {
-            if (!empty($record['context']['exception']) &&
+            if (!empty($record['context']['exception']) && is_object($record['context']['exception']) &&
                 get_class($record['context']['exception']) === DBLogException::class) {
                 //Do nothing if empty log record or an error Exception from itself.
             } else {

--- a/tests/LogToDbTest.php
+++ b/tests/LogToDbTest.php
@@ -245,6 +245,25 @@ class LogToDbTest extends Orchestra\Testbench\TestCase
         $this->expectException(DBLogException::class);
         throw new DBLogException('Dont log this');
     }
+    
+    /**
+     * Test exception when expected format is wrong.
+     *
+     * @group exception
+     */
+    public function testExceptionWrongFormat()
+    {
+        $e = [
+            'message' => 'Array instead exception',
+            'code'    => 0,
+            'file'    => __FILE__,
+            'line'    => __LINE__,
+            'trace'   => debug_backtrace(),
+        ];
+        Log::warning("Error", ['exception' => $e, 'more' => 'infohere']);
+        $log = LogToDB::model()->where('message', 'Error')->first();
+        $this->assertNotEmpty($log->context);
+    }
 
     /**
      *


### PR DESCRIPTION
We make sure that the exception in context is actually an object before attempting to get class of it.