### PR TITLE
Use the collection name as the table name

### DIFF
--- a/src/migrations/2018_08_11_003343_create_log_table.php
+++ b/src/migrations/2018_08_11_003343_create_log_table.php
@@ -13,7 +13,7 @@ class CreateLogTable extends Migration
      */
     public function up()
     {
-        Schema::create('log', function (Blueprint $table) {
+        Schema::create(config('logtodb.collection'), function (Blueprint $table) {
             $table->increments('id');
             $table->text('message')->nullable();
             $table->string('channel')->nullable();
@@ -34,6 +34,6 @@ class CreateLogTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('log');
+        Schema::dropIfExists(config('logtodb.collection'));
     }
 }


### PR DESCRIPTION
Enabling alignment of the migration with the defined settings, in addition to avoiding auto-deploy problems.

When defining a collection name other than the standard 'log', it is necessary to manually change the migration (SQL) so that the table is created with the expected name.