### PR TITLE
Perform migration with configured connection

### DIFF
--- a/src/migrations/2018_08_11_003343_create_log_table.php
+++ b/src/migrations/2018_08_11_003343_create_log_table.php
@@ -13,7 +13,7 @@ class CreateLogTable extends Migration
      */
     public function up()
     {
-        Schema::create(config('logtodb.collection'), function (Blueprint $table) {
+        Schema::connection(config('logtodb.connection'))->create(config('logtodb.collection'), function (Blueprint $table) {
             $table->increments('id');
             $table->text('message')->nullable();
             $table->string('channel')->nullable();
@@ -34,6 +34,6 @@ class CreateLogTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists(config('logtodb.collection'));
+        Schema::connection(config('logtodb.connection'))->dropIfExists(config('logtodb.collection'));
     }
 }


### PR DESCRIPTION
Following the same reasoning as the last PR, just to keep the migration in line with the defined settings.