### PR TITLE
Fix AuthenticatedUserProcessor namespace

### DIFF
--- a/src/Processors/AuthenticatedUserProcessor.php
+++ b/src/Processors/AuthenticatedUserProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Log\Processors;
+namespace danielme85\LaravelLogToDB\Processors;
 
 use Illuminate\Support\Facades\Auth;
 use Monolog\Processor\ProcessorInterface;


### PR DESCRIPTION
Hello,

When I opened the original PR (https://github.com/danielme85/laravel-log-to-db/pull/39), I just copy pasted the code from my Laravel application, without changing the namespace.

This PR fixes it.

In the future, if we add more processors, I will PR tests to avoid this kind of issue.