### PR TITLE
Laravel 10 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.xml
 .phpstorm.meta.php
 _ide_helper.php
 _ide_helper_models.php.php
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,22 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
-        "illuminate/support": ">=5.6"
+        "php": "^8.1",
+        "illuminate/support": "^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": ">=5.0",
-        "mockery/mockery": ">=1.0",
-        "nunomaduro/collision": ">=5.10",
-        "jenssegers/mongodb": ">=3.8"
+        "ext-mongodb": "*",
+        "orchestra/testbench": "^8.0",
+        "mockery/mockery": "^1.5",
+        "nunomaduro/collision": "^7.0",
+        "jenssegers/mongodb": "dev-patch-1"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/saulens22/laravel-mongodb.git"
+        }
+    ],
     "suggest": {
         "jenssegers/mongodb": "Adds support for MongoDB in Laravel/Eloquent"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,14 +19,8 @@
         "orchestra/testbench": "^8.0",
         "mockery/mockery": "^1.5",
         "nunomaduro/collision": "^7.0",
-        "jenssegers/mongodb": "dev-patch-1"
+        "jenssegers/mongodb": "dev-master"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/saulens22/laravel-mongodb.git"
-        }
-    ],
     "suggest": {
         "jenssegers/mongodb": "Adds support for MongoDB in Laravel/Eloquent"
     },

--- a/src/Jobs/SaveNewLogEvent.php
+++ b/src/Jobs/SaveNewLogEvent.php
@@ -6,32 +6,21 @@ use danielme85\LaravelLogToDB\Models\DBLogException;
 use Illuminate\Bus\Queueable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Monolog\LogRecord;
 
 class SaveNewLogEvent implements ShouldQueue
 {
     use InteractsWithQueue, Queueable;
 
     /**
-     * @var object
-     */
-    protected $logToDb;
-
-    /**
-     * @var array
-     */
-    protected $record;
-
-    /**
      * Create a new job instance.
      *
      * @param object $logToDb
-     * @param array $record
+     * @param \Monolog\LogRecord $record
      * @return void
      */
-    public function __construct($logToDb, $record)
+    public function __construct(protected $logToDb, protected LogRecord $record)
     {
-        $this->logToDb = $logToDb;
-        $this->record = $record;
     }
 
     /**

--- a/src/Models/LogToDbCreateObject.php
+++ b/src/Models/LogToDbCreateObject.php
@@ -2,6 +2,8 @@
 
 namespace danielme85\LaravelLogToDB\Models;
 
+use Monolog\LogRecord;
+
 /**
  * Trait LogToDbCreateObject
  *
@@ -12,33 +14,19 @@ trait LogToDbCreateObject
     /**
      * Create a new log object
      *
-     * @param array $record
+     * @param \Monolog\LogRecord $record
      *
      * @return mixed
      */
-    public function generate(array $record)
+    public function generate(LogRecord $record)
     {
-        if (isset($record['message'])) {
-            $this->message = $record['message'];
-        }
-        if (!empty($record['context'])) {
-            $this->context = $record['context'];
-        }
-        if (isset($record['level'])) {
-            $this->level = $record['level'];
-        }
-        if (isset($record['level_name'])) {
-            $this->level_name = $record['level_name'];
-        }
-        if (isset($record['channel'])) {
-            $this->channel = $record['channel'];
-        }
-        if (isset($record['datetime'])) {
-            $this->datetime = $record['datetime'];
-        }
-        if (!empty($record['extra'])) {
-            $this->extra = $record['extra'];
-        }
+        $this->message = $record->message;
+        $this->context = $record->context;
+        $this->level = $record->level->value;
+        $this->level_name = $record->level->getName();
+        $this->channel = $record->channel;
+        $this->datetime = $record->datetime;
+        $this->extra = $record->extra;
         $this->unix_time = time();
 
         return $this;
@@ -185,5 +173,4 @@ trait LogToDbCreateObject
 
         return false;
     }
-
 }

--- a/src/Processors/PhpVersionProcessor.php
+++ b/src/Processors/PhpVersionProcessor.php
@@ -2,6 +2,7 @@
 
 namespace danielme85\LaravelLogToDB\Processors;
 
+use Monolog\LogRecord;
 use Monolog\Processor\ProcessorInterface;
 
 /**
@@ -11,9 +12,9 @@ use Monolog\Processor\ProcessorInterface;
 class PhpVersionProcessor implements ProcessorInterface
 {
     /**
-     * @return array The processed record
+     * @return \Monolog\LogRecord The processed record
      */
-    public function __invoke(array $record) {
+    public function __invoke(LogRecord $record) {
         $record['extra']['php_version'] = phpversion();
 
         return $record;

--- a/tests/FailureTest.php
+++ b/tests/FailureTest.php
@@ -50,7 +50,7 @@ class FailureTest extends Orchestra\Testbench\TestCase
         ini_set('error_log', $backup);
 
         $this->assertStringContainsString(
-            'critical: There was an error while trying to write the log to a DB',
+            'CRITICAL: There was an error while trying to write the log to a DB',
             $result
         );
         $this->assertStringContainsString(

--- a/tests/LogToDbTest.php
+++ b/tests/LogToDbTest.php
@@ -5,6 +5,7 @@ use danielme85\LaravelLogToDB\Models\DBLogException;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use danielme85\LaravelLogToDB\Jobs\SaveNewLogEvent;
+use Monolog\LogRecord;
 
 class LogToDbTest extends Orchestra\Testbench\TestCase
 {
@@ -311,16 +312,15 @@ class LogToDbTest extends Orchestra\Testbench\TestCase
     public function testSaveNewLogEventJob()
     {
         $logToDb = new LogToDB();
-        $record = [
-            'message' => 'job-test',
-            'context' => [],
-            'level' => 200,
-            'level_name' => 'INFO',
-            'channel' => 'local',
-            'datetime' => new Monolog\DateTimeImmutable(true),
-            'extra' => [],
-            'formatted' => "[2019-10-04T17:26:38.446827+00:00] local.INFO: test [] []\n"
-        ];
+        $record = new LogRecord(
+            datetime: new \Monolog\DateTimeImmutable(true),
+            message: 'job-test',
+            context: [],
+            level: \Monolog\Level::Info,
+            channel: 'local',
+            extra: [],
+            formatted: "[2019-10-04T17:26:38.446827+00:00] local.INFO: test [] []\n"
+        );
 
         $job = new SaveNewLogEvent($logToDb, $record);
         $job->handle();


### PR DESCRIPTION
These changes makes library compatible with Laravel v10 / Monolog v3. As there are some breaking changes it should be released as v4.x

Version constrains are updated to non-major version updates as per https://github.com/danielme85/laravel-log-to-db/issues/51

Currently stable version of `jenssegers/laravel-mongodb` have bugs that are fixed in `master`. It should be updated to stable version when it releases.