### PR TITLE
Refactor delete loops to queries

### DIFF
--- a/src/Models/LogToDbCreateObject.php
+++ b/src/Models/LogToDbCreateObject.php
@@ -135,7 +135,7 @@ trait LogToDbCreateObject
         $current = $this->count();
         if ($current > $max) {
             $keepers = $this->orderBy('unix_time', 'DESC')->take($max)->pluck($this->primaryKey)->toArray();
-            if ($this->whereNotIn($this->primaryKey, $keepers)->get()->each->delete()) {
+            if ($this->whereNotIn($this->primaryKey, $keepers)->delete()) {
                 return true;
             }
         }
@@ -163,14 +163,8 @@ trait LogToDbCreateObject
     public function removeOlderThan(string $datetime)
     {
         $unixtime = strtotime($datetime);
-        $deletes = $this->where('unix_time', '<=', $unixtime)->get();
+        $count = $this->where('unix_time', '<=', $unixtime)->delete();
 
-        if (!$deletes->isEmpty()) {
-            if ($deletes->each->delete()) {
-                return true;
-            }
-        }
-
-        return false;
+        return $count > 0;
     }
 }


### PR DESCRIPTION
To delete an object it's not necessary to load it into memory. And by doing one query instead of a delete query for every object, it's much faster.