### PR TITLE
refactor: explicit null types for php 8.4

### DIFF
--- a/src/LogToDB.php
+++ b/src/LogToDB.php
@@ -86,7 +86,7 @@ class LogToDB
      *
      * @return DBLog|DBLogMongoDB
      */
-    public static function model(string $channel = null, string $connection = 'default', string $collection = null)
+    public static function model(?string $channel = null, string $connection = 'default', ?string $collection = null)
     {
         $conn = null;
         $coll = null;


### PR DESCRIPTION
PHP 8.4 prohibits implicit null types and will throw a deprecation warning for it. This PR fixes that.